### PR TITLE
Add command for "single post channels"

### DIFF
--- a/__tests__/commands/chat-input/single-post-channel.test.js
+++ b/__tests__/commands/chat-input/single-post-channel.test.js
@@ -1,0 +1,139 @@
+const { Client, PermissionFlagsBits } = require('discord.js')
+// Mocks must come before command imports
+const discordMock = require('../../../.jest/mock-discord')
+const detaMock = require('../../../.jest/mock-deta')
+// Command Imports must come after mocks
+const { setSPChannel, getSPCStatus, grantSendPermission } = require('../../../src/commands/chat-input/single-post-channel')
+
+const client = discordMock.createClient({}, [])
+const guild = discordMock.createGuild(client, { id: 'g1', everyoneRole: { permissions: PermissionFlagsBits.ViewChannel } })
+client.guilds.cache.set(guild.id, guild)
+const channel = discordMock.createChannel(client, guild, { id: '2', guild, name: 'ch1' })
+client.channels.cache.set(channel.id, channel)
+guild.channels.cache.set(channel.id, channel)
+const user = discordMock.createUser(client, { id: 'u1' })
+client.users.cache.set(user.id, user)
+
+jest.spyOn(Client.prototype, 'emit')
+
+describe('Single Post Channel Add Command', () => {
+  beforeAll(() => {
+    this.interaction = discordMock.createInteraction(client, { channel, channelId: channel.id, guild, guildId: guild.id })
+  })
+  beforeEach(() => {
+    this.interaction.reply.mockClear()
+    detaMock.Base.get.mockReturnValue({})
+  })
+
+  it('Replies with an error if the channel is already a single-post channel', async () => {
+    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
+    const expectedReply = { content: 'Channel is already a single-post channel', ephemeral: true }
+    await setSPChannel(this.interaction, client, true)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+
+  it('Replies that it added the current channel as a single-post channel', async () => {
+    const expectedReply = { content: 'Added <#2> as a single-post channel', ephemeral: true }
+    await setSPChannel(this.interaction, client, true)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+
+  it('Updates the DB with the newly added single-post channel ID', async () => {
+    const expectedDB = { singlePostChannels: ['2'] }
+    await setSPChannel(this.interaction, client, true)
+    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+  })
+
+  it('Emits an event that Single Post Channels were updated', async () => {
+    await setSPChannel(this.interaction, client, true)
+    expect(client.emit).toBeCalledWith('*UpdateSinglePostChannels', 'g1', ['2'])
+  })
+})
+
+describe('Single Post Channel Remove Command', () => {
+  beforeAll(() => {
+    this.interaction = discordMock.createInteraction(client, { channel, channelId: channel.id, guild, guildId: guild.id })
+  })
+  beforeEach(() => {
+    this.interaction.reply.mockClear()
+    detaMock.Base.get.mockReturnValue({})
+  })
+
+  it('Replies with an error if the channel is not a single-post channel', async () => {
+    const expectedReply = { content: 'Channel is not a single-post channel', ephemeral: true }
+    await setSPChannel(this.interaction, client, false)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+
+  it('Replies that the current channel is no longer a single-post channel', async () => {
+    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
+    const expectedReply = { content: '<#2> is no longer a single-post channel', ephemeral: true }
+    await setSPChannel(this.interaction, client, false)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+
+  it('Updates the DB with the newly removed single-post channel ID', async () => {
+    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id, '3'] })
+    const expectedDB = { singlePostChannels: ['3'] }
+    await setSPChannel(this.interaction, client, false)
+    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+  })
+
+  it('Emits an event that Single Post Channels were updated', async () => {
+    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id, '3'] })
+    await setSPChannel(this.interaction, client, false)
+    expect(client.emit).toBeCalledWith('*UpdateSinglePostChannels', 'g1', ['3'])
+  })
+})
+
+describe('Single Post Channel Status Command', () => {
+  beforeAll(() => {
+    this.interaction = discordMock.createInteraction(client, { channel, channelId: channel.id, guild, guildId: guild.id })
+  })
+  beforeEach(() => {
+    this.interaction.reply.mockClear()
+    detaMock.Base.get.mockReturnValue({})
+  })
+
+  it('Replies that the channel is single-post when it is marked', async () => {
+    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
+    const expectedReply = { content: '<#2> currently is a single-post channel', ephemeral: true }
+    await getSPCStatus(this.interaction, client)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+
+  it('Replies that the channel is not single-post when it is not marked', async () => {
+    const expectedReply = { content: '<#2> is currently not a single-post channel', ephemeral: true }
+    await getSPCStatus(this.interaction, client)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+})
+
+describe('Single Post Channel Grant Permissions Command', () => {
+  beforeAll(() => {
+    this.interaction = discordMock.createInteraction(client, { channel, channelId: channel.id, guild, guildId: guild.id })
+    this.interaction.options.getUser.mockReturnValue(user)
+  })
+  beforeEach(() => {
+    this.interaction.reply.mockClear()
+    detaMock.Base.get.mockReturnValue({ singlePostChannels: [channel.id] })
+  })
+
+  it('Replies with an error if the channel is not a single-post channel', async () => {
+    detaMock.Base.get.mockReturnValueOnce({})
+    const expectedReply = { content: 'Channel is not a single-post channel', ephemeral: true }
+    await grantSendPermission(this.interaction, client)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+
+  it('Replies that the send message permission was granted to the user', async () => {
+    const expectedReply = { content: 'Granted send message permission to <@u1>', ephemeral: true }
+    await grantSendPermission(this.interaction, client)
+    expect(this.interaction.reply).toBeCalledWith(expectedReply)
+  })
+
+  it('Creates a permission overwrite that allows the user to view the channel and send messages', async () => {
+    await grantSendPermission(this.interaction, client)
+    expect(channel.permissionOverwrites.create).toBeCalledWith(user.id, { ViewChannel: true, SendMessages: true })
+  })
+})

--- a/src/commands/chat-input/single-post-channel.js
+++ b/src/commands/chat-input/single-post-channel.js
@@ -1,0 +1,111 @@
+// eslint-disable-next-line no-unused-vars
+const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits, PermissionOverwriteManager } = require('discord.js')
+const { Deta } = require('deta')
+const deta = Deta(process.env.DETA_PROJECT_KEY)
+const serverSettingsDB = deta.Base('server-settings')
+
+/**
+ * Sets the "single-post" status of a channel
+ * @param {ChatInputCommandInteraction} interaction The slash command interaction
+ * @param {Client} client The discord bot client
+ * @param {Boolean} active Whether the message counter should be enabled
+ */
+async function setSPChannel (interaction, client, active) {
+  const serverConfig = await serverSettingsDB.get(interaction.guild.id)
+  const spChannels = serverConfig.singlePostChannels ??= []
+
+  const channelID = interaction.channelId
+  if (spChannels.includes(channelID) === active) {
+    const content = `Channel is ${active ? 'already' : 'not'} a single-post channel`
+    return interaction.reply({ content, ephemeral: true })
+  }
+
+  if (active) {
+    spChannels.push(channelID)
+    interaction.reply({ content: `Added <#${channelID}> as a single-post channel`, ephemeral: true })
+  } else {
+    spChannels.splice(spChannels.indexOf(channelID), 1)
+    interaction.reply({ content: `<#${channelID}> is no longer a single-post channel`, ephemeral: true })
+  }
+  await serverSettingsDB.put(serverConfig)
+  client.emit('*UpdateSinglePostChannels', interaction.guild.id, spChannels)
+}
+
+/**
+ * Responds with the "single-post" status of a channel
+ * @param {ChatInputCommandInteraction} interaction The slash command interaction
+ * @param {Client} client The discord bot client
+ * @param {Boolean} active Whether the message counter should be enabled
+ */
+async function getSPCStatus (interaction, client) {
+  const serverConfig = await serverSettingsDB.get(interaction.guild.id)
+  const spChannels = serverConfig.singlePostChannels ??= []
+  const channelID = interaction.channelId
+  const active = spChannels.includes(channelID)
+
+  const content = `<#${channelID}> ${active ? 'currently is' : 'is currently not'} a single-post channel`
+  return interaction.reply({ content, ephemeral: true })
+}
+
+/**
+ * Responds with the "single-post" status of a channel
+ * @param {ChatInputCommandInteraction} interaction The slash command interaction
+ * @param {Client} client The discord bot client
+ * @param {Boolean} active Whether the message counter should be enabled
+ */
+async function grantSendPermission (interaction, client) {
+  const user = interaction.options.getUser('user')
+
+  // Check whether the channel is a single-post channel
+  const serverConfig = await serverSettingsDB.get(interaction.guild.id)
+  const spChannels = serverConfig.singlePostChannels ??= []
+  if (!spChannels.includes(interaction.channelId)) {
+    return interaction.reply({ content: 'Channel is not a single-post channel', ephemeral: true })
+  }
+
+  /** @type {PermissionOverwriteManager} */
+  const overwrites = interaction.channel.permissionOverwrites
+  await overwrites.create(user.id, { ViewChannel: true, SendMessages: true })
+  interaction.reply({ content: `Granted send message permission to ${user}`, ephemeral: true })
+}
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('spc')
+    .setDescription('Configure a channel where users can only post once at a time')
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels | PermissionFlagsBits.Administrator)
+    .addSubcommand(subcommand => {
+      subcommand.setName('add-channel').setDescription('Sets the current channel to a single-post channel')
+      return subcommand
+    })
+    .addSubcommand(subcommand => {
+      subcommand.setName('remove-channel').setDescription('Changes this channel back to a normal channel')
+      return subcommand
+    })
+    .addSubcommand(subcommand => {
+      subcommand.setName('status').setDescription('Returns whether this channel is a single-post channel')
+      return subcommand
+    })
+    .addSubcommand(subcommand => {
+      subcommand.setName('grant')
+        .setDescription('Grants permission for someone to post once to this channel')
+        .addUserOption(option => option
+          .setName('user')
+          .setDescription('The user to grant permission to')
+          .setRequired(true)
+        )
+      return subcommand
+    }),
+  execute: async (interaction, client) => {
+    switch (interaction.options.getSubcommand()) {
+      case 'add-channel': return setSPChannel(interaction, client, true)
+      case 'remove-channel': return setSPChannel(interaction, client, false)
+      case 'status': return getSPCStatus(interaction, client)
+      case 'grant': return grantSendPermission(interaction, client)
+    }
+  },
+  // Expose for tests
+  setSPChannel,
+  getSPCStatus,
+  grantSendPermission
+}

--- a/src/listeners/single-post-channel.js
+++ b/src/listeners/single-post-channel.js
@@ -1,0 +1,39 @@
+// eslint-disable-next-line no-unused-vars
+const { Message, Events, PermissionOverwriteManager } = require('discord.js')
+const { Deta } = require('deta')
+const deta = Deta(process.env.DETA_PROJECT_KEY)
+const serverSettingsDB = deta.Base('server-settings')
+
+const { client } = require('../modules/bot-setup')
+
+/** @type {{ [guildID: string]: string[] }} */
+const singlePostChannels = {}
+
+/**
+ * Scans the chat message for harmful or malicious links
+ * @param {Message} message The chat message
+ */
+async function removeAccess (message) {
+  // Ignore messages sent by bot
+  if (!message.member || message.member.user.bot) return
+  const isSPC = singlePostChannels[message.guildId]?.includes(message.channelId)
+  if (!isSPC) return
+  /** @type {PermissionOverwriteManager} */
+  const overwrites = message.channel.permissionOverwrites
+  overwrites.delete(message.member)
+}
+
+function setSPChannels (guildID, channels) {
+  singlePostChannels[guildID] = channels
+}
+
+client.on(Events.MessageCreate, removeAccess)
+client.on('*UpdateSinglePostChannels', setSPChannels)
+client.once('ready', async () => {
+  const guilds = await client.guilds.fetch()
+  for (const guild of guilds.map(g => g)) {
+    const serverConfig = await serverSettingsDB.get(guild.id)
+    const channels = serverConfig.singlePostChannels || []
+    singlePostChannels[guild.id] = channels
+  }
+})


### PR DESCRIPTION
Primarily for use in the #promotions channel. This will avoid doing the whole dance with temporarily giving people roles and the slow mode thing. It will allow us to be more flexible with the channel (i.e. making it an announcement channel, which doesn't support slow mode; not needing a role for this, etc.)

- Allows channel managers to mark or unmark a channel as a "single post channel"
- Allows channel managers to grant permission to someone to post once in a channel
- Removes permission overwrites when users posts to a single-post channel


https://github.com/treasure-hacks/treasurehacks-bot/assets/54484616/bdd18f12-1d3e-4e28-9480-ad3abc780ef3

