### PR TITLE
Remove `deta` package from the Discord Bot

### DIFF
--- a/.jest/mock-deta.js
+++ b/.jest/mock-deta.js
@@ -1,17 +1,7 @@
 const { createDefaultSettings } = require('../src/listeners/config')
-// const deta = require('deta')
 
 const mockBaseGet = jest.fn(id => createDefaultSettings({ id }))
 const mockBasePut = jest.fn()
-
-// jest.mock('deta', () => ({
-//   Deta: jest.fn(() => ({
-//     Base: jest.fn(() => ({
-//       get: (...args) => mockBaseGet(...args),
-//       put: (...args) => mockBasePut(...args)
-//     }))
-//   }))
-// }))
 
 jest.mock('../src/modules/database', () => ({
   serverSettingsDB: {
@@ -21,6 +11,5 @@ jest.mock('../src/modules/database', () => ({
 }))
 
 module.exports = {
-  Base: { get: mockBaseGet, put: mockBasePut },
   serverSettingsDB: { get: mockBaseGet, put: mockBasePut }
 }

--- a/.jest/mock-deta.js
+++ b/.jest/mock-deta.js
@@ -1,17 +1,17 @@
 const { createDefaultSettings } = require('../src/listeners/config')
-const deta = require('deta')
+// const deta = require('deta')
 
 const mockBaseGet = jest.fn(id => createDefaultSettings({ id }))
 const mockBasePut = jest.fn()
 
-jest.mock('deta', () => ({
-  Deta: jest.fn(() => ({
-    Base: jest.fn(() => ({
-      get: (...args) => mockBaseGet(...args),
-      put: (...args) => mockBasePut(...args)
-    }))
-  }))
-}))
+// jest.mock('deta', () => ({
+//   Deta: jest.fn(() => ({
+//     Base: jest.fn(() => ({
+//       get: (...args) => mockBaseGet(...args),
+//       put: (...args) => mockBasePut(...args)
+//     }))
+//   }))
+// }))
 
 jest.mock('../src/modules/database', () => ({
   serverSettingsDB: {

--- a/.jest/mock-deta.js
+++ b/.jest/mock-deta.js
@@ -13,6 +13,14 @@ jest.mock('deta', () => ({
   }))
 }))
 
+jest.mock('../src/modules/database', () => ({
+  serverSettingsDB: {
+    get: (...args) => mockBaseGet(...args),
+    put: (...args) => mockBasePut(...args)
+  }
+}))
+
 module.exports = {
-  Base: { get: mockBaseGet, put: mockBasePut }
+  Base: { get: mockBaseGet, put: mockBasePut },
+  serverSettingsDB: { get: mockBaseGet, put: mockBasePut }
 }

--- a/.jest/mock-discord.js
+++ b/.jest/mock-discord.js
@@ -1,19 +1,17 @@
 const {
   PermissionOverwrites, PermissionsBitField, RoleManager, PermissionFlagsBits,
   BaseGuildTextChannel, TextChannel, VoiceChannel, StageChannel, ForumChannel,
-  DirectoryChannel, CategoryChannel, PartialTextBasedChannel, BaseGuildVoiceChannel,
+  DirectoryChannel, CategoryChannel, BaseGuildVoiceChannel,
   GuildMemberManager, GuildChannelManager, BaseGuild, InteractionType, CommandInteraction,
   ModalSubmitInteraction, MessageComponentInteraction, ChatInputCommandInteraction,
   ApplicationCommandType, UserContextMenuCommandInteraction, MessageContextMenuCommandInteraction,
-  Message, CommandInteractionOptionResolver, Invite, GuildInviteManager,
+  CommandInteractionOptionResolver, Invite, GuildInviteManager,
   InteractionResponse
 } = require("discord.js")
 const { ChannelType, Client, Guild, BaseInteraction, User,
   GuildChannel, ClientUser, Role, GuildMember, GuildMemberRoleManager,
   PermissionOverwriteManager
 } = require("discord.js")
-// const InteractionResponses = require("discord.js/src/structures/interfaces/InteractionResponses")
-
 
 function resolveTo (value) {
   return new Promise(resolve => resolve(value))

--- a/.jest/mock-discord.js
+++ b/.jest/mock-discord.js
@@ -1,8 +1,18 @@
-const { PermissionOverwrites, PermissionsBitField, RoleManager, PermissionFlagsBits, BaseGuildTextChannel, TextChannel, VoiceChannel, StageChannel, ForumChannel, DirectoryChannel, CategoryChannel, PartialTextBasedChannel, BaseGuildVoiceChannel, GuildMemberManager, GuildChannelManager, BaseGuild, InteractionType, CommandInteraction, ModalSubmitInteraction, MessageComponentInteraction, ChatInputCommandInteraction, ApplicationCommandType, UserContextMenuCommandInteraction, MessageContextMenuCommandInteraction, Message, CommandInteractionOptionResolver, Invite, GuildInviteManager } = require("discord.js")
-const { ChannelType, Client, Guild, BaseInteraction, User,
-  GuildChannel, ClientUser, Role, GuildMember, GuildMemberRoleManager, PermissionOverwriteManager
+const {
+  PermissionOverwrites, PermissionsBitField, RoleManager, PermissionFlagsBits,
+  BaseGuildTextChannel, TextChannel, VoiceChannel, StageChannel, ForumChannel,
+  DirectoryChannel, CategoryChannel, PartialTextBasedChannel, BaseGuildVoiceChannel,
+  GuildMemberManager, GuildChannelManager, BaseGuild, InteractionType, CommandInteraction,
+  ModalSubmitInteraction, MessageComponentInteraction, ChatInputCommandInteraction,
+  ApplicationCommandType, UserContextMenuCommandInteraction, MessageContextMenuCommandInteraction,
+  Message, CommandInteractionOptionResolver, Invite, GuildInviteManager,
+  InteractionResponse
 } = require("discord.js")
-const InteractionResponses = require("discord.js/src/structures/interfaces/InteractionResponses")
+const { ChannelType, Client, Guild, BaseInteraction, User,
+  GuildChannel, ClientUser, Role, GuildMember, GuildMemberRoleManager,
+  PermissionOverwriteManager
+} = require("discord.js")
+// const InteractionResponses = require("discord.js/src/structures/interfaces/InteractionResponses")
 
 
 function resolveTo (value) {
@@ -103,7 +113,7 @@ const interactionType = {
 }
 
 mockClass(CommandInteraction)
-mockClass(InteractionResponses)
+mockClass(InteractionResponse)
 mockClass(ChatInputCommandInteraction)
 mockClass(UserContextMenuCommandInteraction)
 mockClass(MessageContextMenuCommandInteraction)
@@ -126,7 +136,7 @@ function createInteraction (client, options = {}, userData = {}) {
   
   const user = new User(client, userData)
   const Class = interactionType[type]
-  const interactionData = { user, data: { ...options }, type, ...options }
+  const interactionData = { user, data: { ...options }, type, ...options, entitlements: [] }
   if (type === InteractionType.ApplicationCommand) interactionData.data.type = cmdType
   let i = new Class(client, interactionData, options.guild, options.guild?.id || options.guildId)
 

--- a/__tests__/commands/chat-input/attendance.test.js
+++ b/__tests__/commands/chat-input/attendance.test.js
@@ -78,7 +78,7 @@ describe('Attendance Record Command', () => {
     guild.voiceStates.cache.set('1', createVoiceState(channel))
     await recordAttendance(interaction, client)
     expect(guild.fetch).toBeCalled()
-    expect(detaMock.Base.put).toBeCalledWith(expectedConfig)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedConfig)
   })
 })
 
@@ -95,7 +95,7 @@ describe('Attendance List Command', () => {
 
     const config = createDefaultSettings(guild)
     config.attendance = {} // Exists, but no events
-    detaMock.Base.get.mockReturnValue(config)
+    detaMock.serverSettingsDB.get.mockReturnValue(config)
 
     await listAttendance(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith(expectedReply)
@@ -104,14 +104,14 @@ describe('Attendance List Command', () => {
   it('Replies with the correct counts when events exist', async () => {
     const config = createDefaultSettings(guild)
     config.attendance = { [today + ' \u2013 name']: ['user-id', 'u2'], 'Bad name': [] }
-    detaMock.Base.get.mockReturnValue(config)
+    detaMock.serverSettingsDB.get.mockReturnValue(config)
     const expectedReply = { content: `__**${today} \u2013 name:**__ 2\n__**Bad name:**__ 0` }
 
     await listAttendance(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith(expectedReply)
 
     config.attendance = { 'Empty Only': [] }
-    detaMock.Base.get.mockReturnValue(config)
+    detaMock.serverSettingsDB.get.mockReturnValue(config)
     const expected2 = { content: '__**Empty Only:**__ 0' }
 
     await listAttendance(this.interaction, client)

--- a/__tests__/commands/chat-input/config.test.js
+++ b/__tests__/commands/chat-input/config.test.js
@@ -12,7 +12,7 @@ const category = discordMock.createChannel(client, guild, { id: '1', type: Chann
 const channel = discordMock.createChannel(client, guild, { id: '2', guild, name: 'main' })
 guild.channels.cache.set(category.id, category)
 guild.channels.cache.set(channel.id, channel)
-detaMock.Base.get.mockReturnValue({}) // make it completely empty
+detaMock.serverSettingsDB.get.mockReturnValue({}) // make it completely empty
 
 describe('Config Set Log Channel Command', () => {
   beforeAll(() => {
@@ -46,11 +46,11 @@ describe('Config Set Log Channel Command', () => {
     }
     await setLog(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith({ embeds: [expectedEmbed] })
-    expect(detaMock.Base.put).toBeCalledWith({ logChannel: null })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ logChannel: null })
   })
 
   it('Sets the log channel if a valid channel is specified', async () => {
-    detaMock.Base.get.mockReturnValue({ inviteLogChannel: 'blah' }) // make sure it gets rid of this
+    detaMock.serverSettingsDB.get.mockReturnValue({ inviteLogChannel: 'blah' }) // make sure it gets rid of this
     const expectedEmbed = {
       title: 'Success',
       description: 'Set the log channel to <#2>',
@@ -58,7 +58,7 @@ describe('Config Set Log Channel Command', () => {
     }
     await setLog(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith({ embeds: [expectedEmbed], ephemeral: false })
-    expect(detaMock.Base.put).toBeCalledWith({ logChannel: '2' })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ logChannel: '2' })
   })
 })
 
@@ -94,9 +94,9 @@ describe('Config Set Alerts Channel Command', () => {
     }
     await setAlerts(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith({ embeds: [expectedNoSetup] })
-    expect(detaMock.Base.put).toBeCalledWith({ logChannel: null })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ logChannel: null })
 
-    detaMock.Base.get.mockReturnValue({ alertsChannel: 'alerts' })
+    detaMock.serverSettingsDB.get.mockReturnValue({ alertsChannel: 'alerts' })
     this.interaction.options.getChannel.mockReturnValueOnce(undefined)
     const expectedEmbed = {
       title: 'Config',
@@ -105,7 +105,7 @@ describe('Config Set Alerts Channel Command', () => {
     }
     await setAlerts(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith({ embeds: [expectedEmbed] })
-    expect(detaMock.Base.put).toBeCalledWith({ logChannel: null })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ logChannel: null })
   })
 
   it('Sets the alerts channel if a valid channel is specified', async () => {
@@ -116,7 +116,7 @@ describe('Config Set Alerts Channel Command', () => {
     }
     await setAlerts(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith({ embeds: [expectedEmbed], ephemeral: false })
-    expect(detaMock.Base.put).toBeCalledWith({ alertsChannel: '2' })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ alertsChannel: '2' })
   })
 })
 
@@ -127,7 +127,7 @@ describe('Get Feature Config', () => {
 
   it('Returns the correct reply object associated with a key', async () => {
     this.interaction.options.getSubcommand.mockReturnValueOnce('cool-feature')
-    detaMock.Base.get.mockReturnValueOnce({
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({
       coolFeature: { enabled: true },
       'cool-feature': { enabled: false } // it should not pick this one
     })
@@ -145,7 +145,7 @@ describe('Get Feature Config', () => {
 
   it('Returns a reply object containing proper mentions and values', async () => {
     this.interaction.options.getSubcommand.mockReturnValueOnce('feature')
-    detaMock.Base.get.mockReturnValueOnce({
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({
       feature: { enabled: true, channel: 'channel', category: 'cat', foo: 'bar' }
     })
     const ftConfig = await getFeatureConfig(this.interaction, client)
@@ -173,17 +173,17 @@ describe('Update Feature Config', () => {
       get: () => discordMock.createInteraction(client, { guild, options: [this.command], resolved: [this.command] })
     })
     this.interaction.options.getSubcommand.mockReturnValue('feature')
-    detaMock.Base.get.mockReturnValue({
+    detaMock.serverSettingsDB.get.mockReturnValue({
       feature: { enabled: true, channel: 'channel', category: 'cat', foo: 'bar' }
     })
   })
   beforeEach(() => {
-    detaMock.Base.get.mockClear()
-    detaMock.Base.put.mockReset()
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.put.mockReset()
   })
 
   afterAll(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.options.getSubcommand.mockClear()
   })
   afterEach(() => {
@@ -202,7 +202,7 @@ describe('Update Feature Config', () => {
   it('Does not update the database if no options are changed', async () => {
     this.command.options = []
     await updateFeatureConfig(this.interaction, client)
-    expect(detaMock.Base.put).not.toBeCalled()
+    expect(detaMock.serverSettingsDB.put).not.toBeCalled()
   })
 
   it('Replies with the updated config if something changes', async () => {
@@ -235,6 +235,6 @@ describe('Update Feature Config', () => {
       feature: { enabled: false, channel: 'ch2', category: 'cat', foo: 'baz' }
     }
     await updateFeatureConfig(this.interaction, client)
-    expect(detaMock.Base.put).toBeCalledWith(expectedConfig)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedConfig)
   })
 })

--- a/__tests__/commands/chat-input/inviteroles.test.js
+++ b/__tests__/commands/chat-input/inviteroles.test.js
@@ -18,7 +18,7 @@ guild.invites.fetch.mockImplementation(async () => guild.invites.cache)
 const invite = discordMock.createInvite(client, { channel, guild, code: 'INV', id: '11' }, guild)
 guild.invites.cache.set(invite.id, invite)
 
-detaMock.Base.get.mockReturnValue({ inviteRoles: [] })
+detaMock.serverSettingsDB.get.mockReturnValue({ inviteRoles: [] })
 
 const permissions = PermissionFlagsBits.ViewChannel
 const role = discordMock.createRole(client, { name: 'ten', id: '10', permissions }, guild)
@@ -108,7 +108,7 @@ describe('Inviteroles add command', () => {
   })
 
   it('Replies with an error if the rule already exists', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ inviteRoles: [{ name: 'tens' }] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ inviteRoles: [{ name: 'tens' }] })
     const expectedReply = {
       embeds: [{
         color: 0xff0000,
@@ -159,7 +159,7 @@ describe('Inviteroles add command', () => {
       updated_at: 1234
     }
     await addInviteRule(this.interaction, client, false)
-    expect(detaMock.Base.put).toBeCalledWith({ inviteRoles: [expectedConfig] })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ inviteRoles: [expectedConfig] })
   })
 })
 
@@ -188,7 +188,7 @@ describe('Inviteroles details command', () => {
     expect(this.interaction.reply).toBeCalledWith(expectedNoMatchReply)
     this.interaction.reply.mockClear()
 
-    detaMock.Base.get.mockReturnValueOnce({ inviteRoles: [] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ inviteRoles: [] })
     delete this.options.name
     const expectedNoRulesReply = {
       content: 'Details of all role assignments:',
@@ -203,7 +203,7 @@ describe('Inviteroles details command', () => {
   })
 
   it('Replies with all invite role assignment rules if no name is specified', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ inviteRoles: [] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ inviteRoles: [] })
     this.options = {
       name: 'tens',
       rename: 'ten-people',
@@ -252,7 +252,7 @@ describe('Inviteroles delete command', () => {
   })
 
   it('Replies with an error if that invite role assignment does not exist', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ inviteRoles: [] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ inviteRoles: [] })
     const expectedNoMatchReply = {
       embeds: [{
         color: 0xff0000,
@@ -267,7 +267,7 @@ describe('Inviteroles delete command', () => {
   })
 
   it('Replies with the rule that was deleted', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ inviteRoles: [this.rule] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ inviteRoles: [this.rule] })
     const expectedNoMatchReply = {
       embeds: [{
         title: 'Deleted `tens`',
@@ -284,9 +284,9 @@ describe('Inviteroles delete command', () => {
   })
 
   it('Removees the role assigment rule from the database', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ inviteRoles: [this.rule] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ inviteRoles: [this.rule] })
     await removeInviteRule(this.interaction, client)
-    expect(detaMock.Base.put).toBeCalledWith({ inviteRoles: [] })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ inviteRoles: [] })
   })
 })
 
@@ -318,7 +318,7 @@ describe('Inviteroles update command', () => {
       invites: invite.code
     }
     this.interaction.reply.mockClear()
-    detaMock.Base.put.mockClear()
+    detaMock.serverSettingsDB.put.mockClear()
   })
 
   it('Replies with an error if the rule name is invalid', async () => {
@@ -419,7 +419,7 @@ describe('Inviteroles update command', () => {
 
   it('Updates the invite role assignment rule in the database', async () => {
     this.options['remove-roles'] = 'None'
-    detaMock.Base.get.mockReturnValueOnce({ inviteRoles: [this.rule] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ inviteRoles: [this.rule] })
     const expectedConfig = {
       name: 'ten-people',
       invites: ['INV'],
@@ -432,6 +432,6 @@ describe('Inviteroles update command', () => {
     }
     this.interaction.reply.mockImplementation(x => console.log(x))
     await addInviteRule(this.interaction, client, true)
-    expect(detaMock.Base.put).toBeCalledWith({ inviteRoles: [expectedConfig] })
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith({ inviteRoles: [expectedConfig] })
   })
 })

--- a/__tests__/commands/chat-input/leaderboard.test.js
+++ b/__tests__/commands/chat-input/leaderboard.test.js
@@ -26,11 +26,11 @@ function testNonExistent (thisArg, fn) {
       content: 'No such leaderboard with name leaderboard exists',
       ephemeral: true
     }
-    detaMock.Base.get.mockReturnValue({})
+    detaMock.serverSettingsDB.get.mockReturnValue({})
     await fn(thisArg.interaction, client)
     expect(thisArg.interaction.reply).toBeCalledWith(expectedReply)
 
-    detaMock.Base.get.mockReturnValueOnce({ leaderboards: { blah: {} } })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ leaderboards: { blah: {} } })
     await fn(thisArg.interaction, client)
     expect(thisArg.interaction.reply).toBeCalledWith(expectedReply)
   }
@@ -42,9 +42,9 @@ describe('Leaderboard Create Command', () => {
     channel.send.mockReturnValue({ id: '1' })
   })
   beforeEach(() => {
-    detaMock.Base.get.mockClear()
-    detaMock.Base.put.mockReset()
-    detaMock.Base.get.mockReturnValue({})
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.put.mockReset()
+    detaMock.serverSettingsDB.get.mockReturnValue({})
     this.interaction.options.getString
       .mockReturnValueOnce('leaderboard') // Name
       .mockReturnValueOnce('Leaderboard') // Title
@@ -53,7 +53,7 @@ describe('Leaderboard Create Command', () => {
   })
 
   afterAll(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.options.getSubcommand.mockClear()
     channel.send.mockClear()
   })
@@ -62,7 +62,7 @@ describe('Leaderboard Create Command', () => {
   })
 
   it('Replies with an error if a leaderboard with that name already exists', async () => {
-    detaMock.Base.get.mockReturnValueOnce({
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({
       leaderboards: { leaderboard: { title: 'test' } }
     })
     await createLeaderboard(this.interaction, client)
@@ -98,7 +98,7 @@ describe('Leaderboard Create Command', () => {
     }
     this.interaction.options.getChannel.mockReturnValueOnce(undefined)
     await createLeaderboard(this.interaction, client)
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 
   it('Sends a message to the target channel if specified', async () => {
@@ -130,7 +130,7 @@ describe('Leaderboard Create Command', () => {
       scores: {}
     }
     await createLeaderboard(this.interaction, client)
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 })
 
@@ -140,14 +140,14 @@ describe('Leaderboard Delete Command', () => {
     channel.send.mockReturnValue({ id: '1' })
   })
   beforeEach(() => {
-    detaMock.Base.get.mockClear()
-    detaMock.Base.put.mockReset()
-    detaMock.Base.get.mockReturnValue({})
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.put.mockReset()
+    detaMock.serverSettingsDB.get.mockReturnValue({})
     this.interaction.options.getString.mockReturnValue('leaderboard')
   })
 
   afterAll(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.options.getSubcommand.mockClear()
     channel.send.mockClear()
   })
@@ -163,7 +163,7 @@ describe('Leaderboard Delete Command', () => {
       title: 'Leaderboard',
       type: 'user'
     }
-    detaMock.Base.get.mockReturnValueOnce({ leaderboards: { leaderboard } })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ leaderboards: { leaderboard } })
     const expectedReply = {
       embeds: [{
         title: 'Leaderboard Deleted: Leaderboard',
@@ -184,10 +184,10 @@ describe('Leaderboard Delete Command', () => {
       title: 'Leaderboard',
       type: 'user'
     }
-    detaMock.Base.get.mockReturnValueOnce({ leaderboards: { leaderboard } })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ leaderboards: { leaderboard } })
     await deleteLeaderboard(this.interaction, client)
     const expectedDB = { leaderboards: {} }
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 
   it('Deletes the existing leaderboard post, if it exists', async () => {
@@ -203,7 +203,7 @@ describe('Leaderboard Delete Command', () => {
       channelID: '2',
       messageID: '1'
     }
-    detaMock.Base.get.mockReturnValueOnce({ leaderboards: { leaderboard } })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ leaderboards: { leaderboard } })
 
     await deleteLeaderboard(this.interaction, client)
     expect(delFn).toBeCalled()
@@ -229,14 +229,14 @@ describe('Leaderboard Repost Command', () => {
     }
   })
   beforeEach(() => {
-    detaMock.Base.get.mockClear()
-    detaMock.Base.put.mockReset()
-    detaMock.Base.get.mockReturnValue({ leaderboards: { leaderboard: this.leaderboard } })
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.put.mockReset()
+    detaMock.serverSettingsDB.get.mockReturnValue({ leaderboards: { leaderboard: this.leaderboard } })
     this.interaction.options.getString.mockReturnValue('leaderboard')
   })
 
   afterAll(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.options.getSubcommand.mockClear()
     channel.send.mockClear()
   })
@@ -290,7 +290,7 @@ describe('Leaderboard Repost Command', () => {
       scores: {}
     }
     await repostLeaderboard(this.interaction, client)
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 })
 
@@ -306,14 +306,14 @@ describe('Leaderboard Reset Command', () => {
     }
   })
   beforeEach(() => {
-    detaMock.Base.get.mockClear()
-    detaMock.Base.put.mockReset()
-    detaMock.Base.get.mockReturnValue({ leaderboards: { leaderboard: this.leaderboard } })
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.put.mockReset()
+    detaMock.serverSettingsDB.get.mockReturnValue({ leaderboards: { leaderboard: this.leaderboard } })
     this.interaction.options.getString.mockReturnValue('leaderboard')
   })
 
   afterAll(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.options.getSubcommand.mockReset()
     channel.send.mockClear()
   })
@@ -379,7 +379,7 @@ describe('Leaderboard Reset Command', () => {
       scores: {}
     }
     await resetLeaderboard(this.interaction, client)
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 })
 
@@ -400,15 +400,15 @@ describe('Leaderboard Update Command (Post Leaderboards)', () => {
     }
   })
   beforeEach(() => {
-    detaMock.Base.get.mockClear()
-    detaMock.Base.put.mockReset()
-    detaMock.Base.get.mockReturnValue({ leaderboards: { leaderboard: this.leaderboard } })
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.put.mockReset()
+    detaMock.serverSettingsDB.get.mockReturnValue({ leaderboards: { leaderboard: this.leaderboard } })
     this.interaction.options.getString.mockReturnValueOnce('leaderboard') // name
     this.leaderboard.scores = {}
   })
 
   afterAll(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.options.getSubcommand.mockClear()
     channel.send.mockClear()
   })
@@ -491,6 +491,6 @@ describe('Leaderboard Update Command (Post Leaderboards)', () => {
     }
 
     await updatePostsLeaderboard(this.interaction, client)
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 })

--- a/__tests__/commands/chat-input/points.test.js
+++ b/__tests__/commands/chat-input/points.test.js
@@ -22,12 +22,12 @@ describe('Points Command', () => {
     this.interaction.options.getChannel.mockReturnValue(channel)
   })
   beforeEach(() => {
-    detaMock.Base.get.mockClear()
-    detaMock.Base.get.mockReturnValue({})
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.get.mockReturnValue({})
   })
 
   afterEach(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.reply.mockClear()
   })
 
@@ -50,7 +50,7 @@ describe('Points Command', () => {
   })
 
   it('Returns the correct amount of points for each task', async () => {
-    detaMock.Base.get.mockReturnValue({
+    detaMock.serverSettingsDB.get.mockReturnValue({
       messageCounter: { counts: { u1: 1 } },
       attendance: { event: ['u2'] }, // a different user
       leaderboards: { weekly: { scores: { u1: [] } } } // zero
@@ -71,7 +71,7 @@ describe('Points Command', () => {
     await respondWithPoints(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith(expectedReply)
 
-    detaMock.Base.get.mockReturnValue({
+    detaMock.serverSettingsDB.get.mockReturnValue({
       messageCounter: { counts: { u1: 3 } },
       attendance: { event: ['u1'] },
       leaderboards: { weekly: { scores: { u1: [{}, {}] } } } // 2 posts of some sort

--- a/__tests__/commands/chat-input/request.test.js
+++ b/__tests__/commands/chat-input/request.test.js
@@ -27,8 +27,8 @@ describe('Request Channel Command', () => {
   })
   beforeEach(() => {
     this.interaction = discordMock.createInteraction(client, { guild, member })
-    detaMock.Base.get.mockClear()
-    detaMock.Base.get.mockReturnValue({
+    detaMock.serverSettingsDB.get.mockClear()
+    detaMock.serverSettingsDB.get.mockReturnValue({
       alertsChannel: channel.id,
       channelRequest: { enabled: true }
     })
@@ -40,12 +40,12 @@ describe('Request Channel Command', () => {
   })
 
   afterEach(() => {
-    detaMock.Base.get.mockReset()
+    detaMock.serverSettingsDB.get.mockReset()
     this.interaction.reply.mockClear()
   })
 
   it('Replies with an error if channel requests are disabled', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ channelRequest: { enabled: false } })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ channelRequest: { enabled: false } })
     await makeChannelRequest(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith({
       content: 'Unable to send request because requests have not been enabled',
@@ -54,7 +54,7 @@ describe('Request Channel Command', () => {
   })
 
   it('Replies with an error if there is no alerts channel', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ channelRequest: { enabled: true } }) // no alertsChannel
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ channelRequest: { enabled: true } }) // no alertsChannel
     await makeChannelRequest(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith({
       content: 'Unable to send request due to bad host configuration',

--- a/__tests__/commands/chat-input/single-post-channel.test.js
+++ b/__tests__/commands/chat-input/single-post-channel.test.js
@@ -22,11 +22,11 @@ describe('Single Post Channel Add Command', () => {
   })
   beforeEach(() => {
     this.interaction.reply.mockClear()
-    detaMock.Base.get.mockReturnValue({})
+    detaMock.serverSettingsDB.get.mockReturnValue({})
   })
 
   it('Replies with an error if the channel is already a single-post channel', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
     const expectedReply = { content: 'Channel is already a single-post channel', ephemeral: true }
     await setSPChannel(this.interaction, client, true)
     expect(this.interaction.reply).toBeCalledWith(expectedReply)
@@ -41,7 +41,7 @@ describe('Single Post Channel Add Command', () => {
   it('Updates the DB with the newly added single-post channel ID', async () => {
     const expectedDB = { singlePostChannels: ['2'] }
     await setSPChannel(this.interaction, client, true)
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 
   it('Emits an event that Single Post Channels were updated', async () => {
@@ -56,7 +56,7 @@ describe('Single Post Channel Remove Command', () => {
   })
   beforeEach(() => {
     this.interaction.reply.mockClear()
-    detaMock.Base.get.mockReturnValue({})
+    detaMock.serverSettingsDB.get.mockReturnValue({})
   })
 
   it('Replies with an error if the channel is not a single-post channel', async () => {
@@ -66,21 +66,21 @@ describe('Single Post Channel Remove Command', () => {
   })
 
   it('Replies that the current channel is no longer a single-post channel', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
     const expectedReply = { content: '<#2> is no longer a single-post channel', ephemeral: true }
     await setSPChannel(this.interaction, client, false)
     expect(this.interaction.reply).toBeCalledWith(expectedReply)
   })
 
   it('Updates the DB with the newly removed single-post channel ID', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id, '3'] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ singlePostChannels: [channel.id, '3'] })
     const expectedDB = { singlePostChannels: ['3'] }
     await setSPChannel(this.interaction, client, false)
-    expect(detaMock.Base.put).toBeCalledWith(expectedDB)
+    expect(detaMock.serverSettingsDB.put).toBeCalledWith(expectedDB)
   })
 
   it('Emits an event that Single Post Channels were updated', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id, '3'] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ singlePostChannels: [channel.id, '3'] })
     await setSPChannel(this.interaction, client, false)
     expect(client.emit).toBeCalledWith('*UpdateSinglePostChannels', 'g1', ['3'])
   })
@@ -92,11 +92,11 @@ describe('Single Post Channel Status Command', () => {
   })
   beforeEach(() => {
     this.interaction.reply.mockClear()
-    detaMock.Base.get.mockReturnValue({})
+    detaMock.serverSettingsDB.get.mockReturnValue({})
   })
 
   it('Replies that the channel is single-post when it is marked', async () => {
-    detaMock.Base.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({ singlePostChannels: [channel.id] })
     const expectedReply = { content: '<#2> currently is a single-post channel', ephemeral: true }
     await getSPCStatus(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith(expectedReply)
@@ -116,11 +116,11 @@ describe('Single Post Channel Grant Permissions Command', () => {
   })
   beforeEach(() => {
     this.interaction.reply.mockClear()
-    detaMock.Base.get.mockReturnValue({ singlePostChannels: [channel.id] })
+    detaMock.serverSettingsDB.get.mockReturnValue({ singlePostChannels: [channel.id] })
   })
 
   it('Replies with an error if the channel is not a single-post channel', async () => {
-    detaMock.Base.get.mockReturnValueOnce({})
+    detaMock.serverSettingsDB.get.mockReturnValueOnce({})
     const expectedReply = { content: 'Channel is not a single-post channel', ephemeral: true }
     await grantSendPermission(this.interaction, client)
     expect(this.interaction.reply).toBeCalledWith(expectedReply)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@types/jsdom": "^21.1.6",
         "buffer-chunks": "^0.1.1",
         "cors": "^2.8.5",
-        "deta": "^2.0.0",
         "discord-html-transcripts": "^3.2.0",
         "discord.js": "^14.14.1",
         "dotenv": "^16.4.5",
@@ -2840,14 +2839,6 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/deta": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deta/-/deta-2.0.0.tgz",
-      "integrity": "sha512-ve+WITlmfT5nJhhdPkUWRHL3x1x9J5mZouIS0zfYR9N/WXYVWdX8muBpFVS5L0Jwxmsvgnbe4I7e1aOrrjIctg==",
-      "dependencies": {
-        "node-fetch": "^2.6.7"
       }
     },
     "node_modules/detect-newline": {
@@ -5902,25 +5893,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7320,11 +7292,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
     "node_modules/ts-api-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
@@ -7662,11 +7629,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -7695,15 +7657,6 @@
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "jest": "^29.7.0",
         "joi": "^17.11.0",
         "jsdom": "^24.0.0",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "mongoose": "^8.6.1"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -866,20 +867,24 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.7.0.tgz",
-      "integrity": "sha512-GDtbKMkg433cOZur8Dv6c25EHxduNIBsxeHrsRoIM8+AwmEZ8r0tEpckx/sHwTLwQPOF3e2JWloZh9ofCaMfAw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.9.0.tgz",
+      "integrity": "sha512-0zx8DePNVvQibh5ly5kCEei5wtPBIUbSoE9n+91Rlladz4tgtFbJ36PZMxxZrTEOQ7AHMZ/b0crT/0fCy6FTKg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.3",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/shapeshift": "^3.9.3",
-        "discord-api-types": "0.37.61",
+        "@discordjs/formatters": "^0.5.0",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "0.37.97",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
-        "tslib": "^2.6.2"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/collection": {
@@ -891,77 +896,116 @@
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.3.tgz",
-      "integrity": "sha512-wTcI1Q5cps1eSGhl6+6AzzZkBBlVrBdc9IUhJbijRgVjCNIIIZPgqnUj3ntFODsHrdbGU8BEG9XmDQmgEEYn3w==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.5.0.tgz",
+      "integrity": "sha512-98b3i+Y19RFq1Xke4NkVY46x8KjJQjldHUuEbCqMvp1F5Iq9HgnGpu91jOi/Ufazhty32eRsKnnzS8n4c+L93g==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "discord-api-types": "0.37.61"
+        "discord-api-types": "0.37.97"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.2.0.tgz",
-      "integrity": "sha512-nXm9wT8oqrYFRMEqTXQx9DUTeEtXUDMmnUKIhZn6O2EeDY9VCdwj23XCPq7fkqMPKdF7ldAfeVKyxxFdbZl59A==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.0.tgz",
+      "integrity": "sha512-Xb2irDqNcq+O8F0/k/NaDp7+t091p+acb51iA4bCKfIn+WFWd6HrNvcsSbMMxIR9NjcMZS6NReTKygqiQN+ntw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/collection": "^2.0.0",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.5.1",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.61",
-        "magic-bytes.js": "^1.5.0",
-        "tslib": "^2.6.2",
-        "undici": "5.28.4"
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "0.37.97",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.19.8"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
-      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.0.2.tgz",
-      "integrity": "sha512-IRNbimrmfb75GMNEjyznqM1tkI7HrZOf14njX7tCAAUetyZM1Pr8hX/EK2lxBCOgWDRmigbp24fD1hdMfQK5lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.0.2.tgz",
-      "integrity": "sha512-+XI82Rm2hKnFwAySXEep4A7Kfoowt6weO6381jgW+wVdTpMS/56qCvoXyFRY0slcv7c/U8My2PwIB2/wEaAh7Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.1.1.tgz",
+      "integrity": "sha512-PZ+vLpxGCRtmr2RMkqh8Zp+BenUaJqlS6xhgWKEZcgC/vfHLEzpHtKkB0sl3nZWpwtcKk6YWy+pU3okL2I97FA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/collection": "^2.0.0",
-        "@discordjs/rest": "^2.1.0",
-        "@discordjs/util": "^1.0.2",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.9",
-        "@vladfrangu/async_event_emitter": "^2.2.2",
-        "discord-api-types": "0.37.61",
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.3.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "0.37.83",
         "tslib": "^2.6.2",
-        "ws": "^8.14.2"
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.0.0.tgz",
-      "integrity": "sha512-YTWIXLrf5FsrLMycpMM9Q6vnZoR/lN2AWX23/Cuo8uOOtS8eHB2dyQaaGnaF8aZPYnttf2bkLMcXn/j6JUOi3w==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
+    },
+    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
+      "version": "0.37.83",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.83.tgz",
+      "integrity": "sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA==",
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -1389,6 +1433,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1425,31 +1478,33 @@
       }
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.1.tgz",
-      "integrity": "sha512-1RdpsmDQR/aWfp8oJzPtn4dNQrbpqSL5PIA0uAB/XwerPXUf994Ug1au1e7uGcD7ei8/F63UDjr5GWps1g/HxQ==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
+      "integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
+      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.4.tgz",
-      "integrity": "sha512-SiOoCBmm8O7QuadLJnX4V0tAkhC54NIOZJtmvw+5zwnHaiulGkjY02wxCuK8Gf4V540ILmGz+UulC0U8mrOZjg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=v16"
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -1635,10 +1690,26 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="
     },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
     "node_modules/@types/ws": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.9.tgz",
-      "integrity": "sha512-jbdrY0a8lxfdTp/+r7Z4CkycbOFN8WX+IOchLJr3juT/xzbJ8URyTVSJ/hvNdadTgM1mnedb47n+Y31GsFnQlg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
+      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1793,9 +1864,10 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
-      "integrity": "sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -2260,11 +2332,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2307,6 +2380,15 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.8.0.tgz",
+      "integrity": "sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer-chunks": {
@@ -2797,9 +2879,10 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.61",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
-      "integrity": "sha512-o/dXNFfhBpYHpQFdT6FWzeO7pKc838QeeZ9d91CfVAtpr5XLK4B/zYxQbYgPdoMiTDvJfzcsLW5naXgmHGDNXw=="
+      "version": "0.37.97",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.97.tgz",
+      "integrity": "sha512-No1BXPcVkyVD4ZVmbNgDKaBoqgeQ+FJpzZ8wqHkfmBnTZig1FcH3iPPersiK1TUIAzgClh2IvOuVUYfcWLQAOA==",
+      "license": "MIT"
     },
     "node_modules/discord-html-transcripts": {
       "version": "3.2.0",
@@ -2828,27 +2911,38 @@
       }
     },
     "node_modules/discord.js": {
-      "version": "14.14.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.14.1.tgz",
-      "integrity": "sha512-/hUVzkIerxKHyRKopJy5xejp4MYKDPTszAnpYxzVVv4qJYf+Tkt+jnT2N29PIPschicaEEpXwF2ARrTYHYwQ5w==",
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.16.1.tgz",
+      "integrity": "sha512-/diX4shp3q1F3EySGQbQl10el+KIpffLSOJdtM35gGV7zw2ED7rKbASKJT7UIR9L/lTd0KtNenZ/h739TN7diA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@discordjs/builders": "^1.7.0",
+        "@discordjs/builders": "^1.9.0",
         "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.3.3",
-        "@discordjs/rest": "^2.1.0",
-        "@discordjs/util": "^1.0.2",
-        "@discordjs/ws": "^1.0.2",
-        "@sapphire/snowflake": "3.5.1",
-        "@types/ws": "8.5.9",
-        "discord-api-types": "0.37.61",
+        "@discordjs/formatters": "^0.5.0",
+        "@discordjs/rest": "^2.4.0",
+        "@discordjs/util": "^1.1.1",
+        "@discordjs/ws": "1.1.1",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "0.37.97",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
-        "tslib": "2.6.2",
-        "undici": "5.28.4",
-        "ws": "8.14.2"
+        "tslib": "^2.6.3",
+        "undici": "6.19.8"
       },
       "engines": {
-        "node": ">=16.11.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/discord.js/node_modules/undici": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/doctrine": {
@@ -3651,9 +3745,10 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -4430,6 +4525,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -5332,26 +5428,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
-      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5422,6 +5498,15 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/kareem": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5478,7 +5563,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5520,9 +5606,10 @@
       }
     },
     "node_modules/magic-bytes.js": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.6.0.tgz",
-      "integrity": "sha512-eOGBE+NSCwU9dKKox93BPHjX4KSxIuiRY1/H1lkfxIagT0Llhs6bkRk8iqoP/0aeDl7FEZPa+ln5lay5mcNY4w=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
+      "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
+      "license": "MIT"
     },
     "node_modules/make-dir": {
       "version": "4.0.0",
@@ -5554,6 +5641,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -5582,11 +5675,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -5649,6 +5743,145 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
+      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/mongoose": {
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.6.1.tgz",
+      "integrity": "sha512-dppGcYqvsdg+VcnqXR5b467V4a+iNhmvkfYNpEPi6AjaUxnz6ioEDmrMLOi+sOWjvoHapuwPOigV4f2l7HC6ag==",
+      "license": "MIT",
+      "dependencies": {
+        "bson": "^6.7.0",
+        "kareem": "2.6.3",
+        "mongodb": "6.8.0",
+        "mpath": "0.9.0",
+        "mquery": "5.0.0",
+        "ms": "2.1.3",
+        "sift": "17.1.3"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mpath": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.9.0.tgz",
+      "integrity": "sha512-ikJRQTk8hw5DEoFVxHG1Gn9T/xcjtdnOKIU1JTmGjZZlg9LST2mBLmcX3/ICIbgJydT2GOc15RnNy5mHmzfSew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mquery": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {
@@ -6703,6 +6936,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sift": {
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
+      "license": "MIT"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6773,6 +7012,15 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
       }
     },
     "node_modules/sprintf-js": {
@@ -7030,6 +7278,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -7089,9 +7338,10 @@
       }
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
+      "license": "MIT"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -7106,9 +7356,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
     },
     "node_modules/twemoji": {
       "version": "14.0.2",
@@ -7538,9 +7789,10 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "jest": "^29.7.0",
     "joi": "^17.11.0",
     "jsdom": "^24.0.0",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "mongoose": "^8.6.1"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@types/jsdom": "^21.1.6",
     "buffer-chunks": "^0.1.1",
     "cors": "^2.8.5",
-    "deta": "^2.0.0",
     "discord-html-transcripts": "^3.2.0",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.5",

--- a/src/commands/chat-input/attendance.js
+++ b/src/commands/chat-input/attendance.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits, ChannelType } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /**
  * Handles the slash command interaction

--- a/src/commands/chat-input/config.js
+++ b/src/commands/chat-input/config.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, ChannelType, SlashCommandBuilder, PermissionFlagsBits } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /** @todo move this somewhere else */
 function dashedToCamelCase (str) {

--- a/src/commands/chat-input/inviteroles.js
+++ b/src/commands/chat-input/inviteroles.js
@@ -1,9 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits, AutocompleteInteraction, Collection, AutocompleteFocusedOption, Invite } = require('discord.js')
-const { Deta } = require('deta')
 const { getStats } = require('../../modules/role-stats')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 const isValidRole = role => !role.managed && role.name !== '@everyone'
 /**
@@ -213,7 +211,7 @@ async function listInviteRoles (interaction, client) {
       title: `Invite Role Assignment: ${rule.name}`,
       color: rule.color,
       description: (rule.description ? rule.description + '\n\n' : '') +
-        `Applies to invites: ${rule.invites.join(', ')}` +
+        `Applies to invites: ${rule.invites?.join(', ') || []}` +
         `\nPeople invited will have these roles: ${rule.rolesToAdd.map(role => `<@&${role}>`).join(', ')}` +
         `\nPeople invited will lose these roles: ${rule.rolesToRemove.map(role => `<@&${role}>`).join(', ')}`,
       footer: {

--- a/src/commands/chat-input/leaderboard.js
+++ b/src/commands/chat-input/leaderboard.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits, ChannelType } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 const { getLeaderboard, generateLeaderboardPost, updateLeaderboardPost, getLeaderboardMessage } = require('../../scripts/leaderboard')
 
 /**

--- a/src/commands/chat-input/link-scanner.js
+++ b/src/commands/chat-input/link-scanner.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 const defaultServerConfig = { enabled: false, ignoredRoles: [] }
 

--- a/src/commands/chat-input/message-counter.js
+++ b/src/commands/chat-input/message-counter.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 const defaultServerConfig = { enabled: false, ignoredRoles: [], counts: {} }
 

--- a/src/commands/chat-input/most-helpful.js
+++ b/src/commands/chat-input/most-helpful.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { SlashCommandBuilder, Client, ChatInputCommandInteraction, PermissionFlagsBits } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /**
  * Replies with who has helped others the most times

--- a/src/commands/chat-input/points.js
+++ b/src/commands/chat-input/points.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /**
  * Responds to the user with the number of points they have, that is, the number of messages

--- a/src/commands/chat-input/request.js
+++ b/src/commands/chat-input/request.js
@@ -1,9 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 const { ChatInputCommandInteraction, SlashCommandBuilder, Client } = require('discord.js')
-const { Deta } = require('deta')
 const { sendMessage } = require('../../modules/message')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /**
  * Gets the feature config reply for the current feature

--- a/src/commands/chat-input/scam-checker.js
+++ b/src/commands/chat-input/scam-checker.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 const defaultServerConfig = { enabled: false, ignoredRoles: [], maxDays: 7 }
 

--- a/src/commands/chat-input/single-post-channel.js
+++ b/src/commands/chat-input/single-post-channel.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Client, ChatInputCommandInteraction, SlashCommandBuilder, PermissionFlagsBits, PermissionOverwriteManager } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /**
  * Sets the "single-post" status of a channel

--- a/src/commands/context-menu/mark-helpful.js
+++ b/src/commands/context-menu/mark-helpful.js
@@ -1,9 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 const { ContextMenuCommandBuilder, ApplicationCommandType, MessageContextMenuCommandInteraction, Client, PermissionFlagsBits } = require('discord.js')
 const { sendMessage, getLogChannel } = require('../../modules/message')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /**
  * Gets the "helped times" text

--- a/src/commands/context-menu/mark-not-helpful.js
+++ b/src/commands/context-menu/mark-not-helpful.js
@@ -1,9 +1,7 @@
 // eslint-disable-next-line no-unused-vars
 const { ContextMenuCommandBuilder, ApplicationCommandType, MessageContextMenuCommandInteraction, Client, PermissionFlagsBits } = require('discord.js')
 const { getLogChannel, sendMessage } = require('../../modules/message')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../../modules/database')
 
 /**
  * Gets the "helped times" text

--- a/src/listeners/automod-strikes.js
+++ b/src/listeners/automod-strikes.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Events, AutoModerationActionExecution, AutoModerationActionType, GuildChannel, GuildMember, Message } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 
 const { client } = require('../modules/bot-setup')
 const { searchByID } = require('../modules/members')

--- a/src/listeners/config.js
+++ b/src/listeners/config.js
@@ -1,8 +1,6 @@
 const { Events } = require('discord.js')
 const { client } = require('../modules/bot-setup')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 
 /**
  * Returns an object containing the default bot settings for the guild
@@ -15,7 +13,7 @@ function createDefaultSettings (guild) {
     logChannel: null,
     alertsChannel: null,
     inviteRoles: [],
-    linkScanner: { enabled: true, ignoredRoles: [] },
+    linkScanner: { enabled: false, ignoredRoles: [] },
     channelRequest: { enabled: false }
   }
 }

--- a/src/listeners/inviteroles.js
+++ b/src/listeners/inviteroles.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Collection, GuildMember, Events } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 
 const { client } = require('../modules/bot-setup')
 const { sendMessage } = require('../modules/message')

--- a/src/listeners/link-scanner.js
+++ b/src/listeners/link-scanner.js
@@ -1,10 +1,10 @@
 // eslint-disable-next-line no-unused-vars
 const { Message, Events } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const urlSafetyDB = deta.Base('domain-reputations')
-const serverSettingsDB = deta.Base('server-settings')
-const { sendMessage, sendEmbeds } = require('../modules/message')
+// const deta = Deta(process.env.DETA_PROJECT_KEY)
+// const serverSettingsDB = deta.Base('server-settings')
+// const urlSafetyDB = deta.Base('domain-reputations')
+// const { sendMessage, sendEmbeds } = require('../modules/message')
+const { serverSettingsDB } = require('../modules/database')
 
 const { client } = require('../modules/bot-setup')
 
@@ -18,67 +18,70 @@ async function scanMessage (message) {
   const serverConfig = await serverSettingsDB.get(message.guild.id)
   if (!serverConfig.linkScanner?.enabled) return
 
-  const logOnlyRoles = serverConfig.linkScanner?.ignoredRoles || []
-  const actionableUser = !logOnlyRoles.some(id => {
-    return message.member.roles.cache.map(r => r.id).includes(id)
-  })
+  console.log('Scanner functionality not active.')
 
-  const channels = await message.guild.channels.fetch()
-  const logChannel = channels.get(serverConfig.logChannel)
+  // const logOnlyRoles = serverConfig.linkScanner?.ignoredRoles || []
+  // const actionableUser = !logOnlyRoles.some(id => {
+  //   return message.member.roles.cache.map(r => r.id).includes(id)
+  // })
 
-  const urlMatches = message.content.match(/\w+:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g) || []
+  // const channels = await message.guild.channels.fetch()
+  // const logChannel = channels.get(serverConfig.logChannel)
 
-  let postDeleted = false;
-  [...new Set(urlMatches)].forEach(async match => {
-    // Return if no url or if message can't be deleted
-    if (!match) return
-    const url = new URL(match)
-    let entry = await urlSafetyDB.get(url.hostname)
-    if (!entry) {
-      // eslint-disable-next-line
-      entry = await fetch(`https://ipqualityscore.com/api/json/url/${process.env.IPQS_KEY}/${encodeURIComponent(url.hostname)}`)
-        .then(x => x.json())
-        .catch(() => sendMessage(logChannel, 'Unabled to scan hostname ' + url.hostname))
-      console.log(`New hostname added to database: ${url.hostname}`)
-      urlSafetyDB.put(entry, url.hostname, { expireIn: 2592000 }) // Expire in 1 month
-    }
-    const { risk_score: riskScore } = entry
-    let timeoutHours = 24
-    const actions = []
-    /* eslint-disable no-fallthrough */
-    switch (true) {
-      case actionableUser && riskScore >= 85: // Longer Timeout, Delete, respond, log
-        timeoutHours = 48
-      case actionableUser && riskScore >= 75: // Timeout, Delete, respond, log
-        message.member.timeout(timeoutHours * 3600 * 1000, 'Posting harmful links')
-          .catch(e => console.error('Cannot timeout user', e))
-        actions.push('timeout user')
-      case actionableUser && riskScore >= 50: {
-        // Delete, respond, log
-        if (!postDeleted && message.deletable) {
-          postDeleted = true
-          await message.reply({ content: 'Message was deleted because it contained a harmful link' })
-            .catch(e => /* could not reply */ console.error(e))
-          await message.delete()
-        }
-        actions.push('delete message')
-      }
-      case riskScore >= 25: // log
-        actions.push('log URL')
-        sendEmbeds(logChannel, [{
-          color: parseInt('b81414', 16),
-          author: { name: message.member.user.username, iconURL: message.member.displayAvatarURL() },
-          title: 'Message had a flagged URL',
-          description: `Sent by <@!${message.member.id}> in <#${message.channel.id}>\nActions Taken: ${actions.join(', ')}`,
-          fields: [
-            { name: 'URL', value: `${url.href}`, inline: true },
-            { name: 'Risk Score', value: String(riskScore), inline: true }
-          ],
-          timestamp: Date.now()
-        }])
-    }
-    /* eslint-enable no-fallthrough */
-  })
+  // const urlMatches = message.content.match(/\w+:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/g) || []
+
+  // let postDeleted = false;
+  // [...new Set(urlMatches)].forEach(async match => {
+  //   // Return if no url or if message can't be deleted
+  //   if (!match) return
+  //   const url = new URL(match)
+  //   let entry = await urlSafetyDB.get(url.hostname)
+  //   if (!entry) {
+  //     // eslint-disable-next-line
+  //     entry = await fetch(`https://ipqualityscore.com/api/json/url/${process.env.IPQS_KEY}/${encodeURIComponent(url.hostname)}`)
+  //       .then(x => x.json())
+  //       .catch(() => sendMessage(logChannel, 'Unabled to scan hostname ' + url.hostname))
+  //     console.log(`New hostname added to database: ${url.hostname}`)
+  //     urlSafetyDB.put(entry, url.hostname, { expireIn: 2592000 }) // Expire in 1 month
+  //   }
+  //   const { risk_score: riskScore } = entry
+  //   let timeoutHours = 24
+  //   const actions = []
+  //   /* eslint-disable no-fallthrough */
+  //   switch (true) {
+  //     case actionableUser && riskScore >= 85: // Longer Timeout, Delete, respond, log
+  //       timeoutHours = 48
+  //     case actionableUser && riskScore >= 75: // Timeout, Delete, respond, log
+  //       message.member.timeout(timeoutHours * 3600 * 1000, 'Posting harmful links')
+  //         .catch(e => console.error('Cannot timeout user', e))
+  //       actions.push('timeout user')
+  //     case actionableUser && riskScore >= 50: {
+  //       // Delete, respond, log
+  //       if (!postDeleted && message.deletable) {
+  //         postDeleted = true
+  //         await message.reply({ content: 'Message was deleted because it contained a harmful link' })
+  //           .catch(e => /* could not reply */ console.error(e))
+  //         await message.delete()
+  //       }
+  //       actions.push('delete message')
+  //     }
+  //     case riskScore >= 25: // log
+  //       actions.push('log URL')
+  //       sendEmbeds(logChannel, [{
+  //         color: parseInt('b81414', 16),
+  //         author: { name: message.member.user.username, iconURL: message.member.displayAvatarURL() },
+  //         title: 'Message had a flagged URL',
+  //         description: `Sent by <@!${message.member.id}> in <#${message.channel.id}>\nActions Taken: ${actions.join(', ')}`,
+  //         fields: [
+  //           { name: 'URL', value: `${url.href}`, inline: true },
+  //           { name: 'Risk Score', value: String(riskScore), inline: true }
+  //         ],
+  //         timestamp: Date.now()
+  //       }])
+  //   }
+  //   /* eslint-enable no-fallthrough */
+  // })
 }
 
-client.on(Events.MessageCreate, scanMessage)
+// disable this listener
+client.on(Events.MessageCreate, (() => {}) || scanMessage)

--- a/src/listeners/message-counter.js
+++ b/src/listeners/message-counter.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Message, Events } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 
 const { client } = require('../modules/bot-setup')
 

--- a/src/listeners/scams.js
+++ b/src/listeners/scams.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Message, Events } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 
 const { client } = require('../modules/bot-setup')
 

--- a/src/listeners/single-post-channel.js
+++ b/src/listeners/single-post-channel.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { Message, Events, PermissionOverwriteManager } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 
 const { client } = require('../modules/bot-setup')
 

--- a/src/modal-actions/leaderboard.js
+++ b/src/modal-actions/leaderboard.js
@@ -1,9 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { ModalSubmitInteraction } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
-// const { getAlertsChannel, sendMessageAsync } = require('../modules/message')
+const { serverSettingsDB } = require('../modules/database')
 const { getLeaderboard, updateLeaderboardPost, getLeaderboardMessage } = require('../scripts/leaderboard')
 
 /**

--- a/src/modules/database.js
+++ b/src/modules/database.js
@@ -26,7 +26,7 @@ const serverSettingsDB = {
   put: async function (data) {
     const id = data.key
     delete data.key
-    await ServerSettings.findByIdAndUpdate(id, data)
+    await ServerSettings.findByIdAndUpdate(id, data, { new: true, upsert: true })
   }
 }
 

--- a/src/modules/database.js
+++ b/src/modules/database.js
@@ -1,0 +1,33 @@
+const mongoose = require('mongoose')
+mongoose.connect(process.env.MONGO_URL).then(() => console.log('Connected to DB'))
+
+const ServerSettings = mongoose.model('server-settings', new mongoose.Schema({
+  _id: String,
+  alertsChannel: String,
+  attendance: Object,
+  channelRequest: { enabled: Boolean, syncFirst: Boolean, category: String },
+  cryptoScamScanner: { enabled: Boolean, maxDays: Number, ignoredRoles: [{ type: String }] },
+  helpfulMessages: { type: [{ type: { channel: String, id: String, user: String } }], default: undefined },
+  inviteRoles: { type: Array, default: undefined },
+  leaderboards: Object,
+  linkScanner: { enabled: Boolean, ignoredRoles: [{ type: String }] },
+  logChannel: String,
+  messageCounter: { enabled: Boolean, counts: Object, ignoredRoles: [{ type: String }] },
+  singlePostChannels: { type: Array, default: undefined }
+}, { versionKey: false }))
+
+const serverSettingsDB = {
+  get: async function (serverID) {
+    const response = await ServerSettings.findById(serverID).lean()
+    // for auto type recognition to be correct
+    const data = { ...response, key: response._id, _id: undefined }
+    return data
+  },
+  put: async function (data) {
+    const id = data.key
+    delete data.key
+    await ServerSettings.findByIdAndUpdate(id, data)
+  }
+}
+
+module.exports = { serverSettingsDB }

--- a/src/modules/database.js
+++ b/src/modules/database.js
@@ -19,6 +19,8 @@ const ServerSettings = mongoose.model('server-settings', new mongoose.Schema({
 const serverSettingsDB = {
   get: async function (serverID) {
     const response = await ServerSettings.findById(serverID).lean()
+    if (!response) return null
+
     // for auto type recognition to be correct
     const data = { ...response, key: response._id, _id: undefined }
     return data

--- a/src/modules/message.js
+++ b/src/modules/message.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 const { EmbedBuilder, Guild, Channel } = require('discord.js')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 
 /**
  * Gets the log channel of the guild

--- a/src/scripts/channel-request.js
+++ b/src/scripts/channel-request.js
@@ -1,6 +1,4 @@
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 // eslint-disable-next-line no-unused-vars
 const { ModalSubmitInteraction, PermissionsBitField, ChannelType } = require('discord.js')
 

--- a/src/scripts/role-manager.js
+++ b/src/scripts/role-manager.js
@@ -1,7 +1,5 @@
 const { client } = require('../modules/bot-setup')
-const { Deta } = require('deta')
-const deta = Deta(process.env.DETA_PROJECT_KEY)
-const serverSettingsDB = deta.Base('server-settings')
+const { serverSettingsDB } = require('../modules/database')
 const { sendMessage } = require('../modules/message')
 
 async function logRoleAddition (guild, member, role, reason) {


### PR DESCRIPTION
- Creates a drop-in wrapper object for all `server-settings` DB actions. This is different from the API's approach since the bot primarily relies only on one collection.
- Updated tests to mock the MongoDB functions instead of Deta Base functions
- You will need to add the `MONGO_URL` env variable (same as SDR)

**PLEASE TEST THE DISCORD BOT LOCALLY AND TRY TO BREAK IT**

---
_**I might rename `mock-deta.js` and delete `link-scanner.js` after review**_